### PR TITLE
fix dead lock bug and optimize.

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -403,9 +403,9 @@ func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, sctx sessionctx.Co
 	}
 	if txn.Valid() && txn.IsPessimistic() {
 		p := txn.(pessimisticTxn)
-		keys, err := p.FreshModifiedKeys()
-		if err != nil {
-			return nil, err
+		keys, err1 := p.FreshModifiedKeys()
+		if err1 != nil {
+			return nil, err1
 		}
 		if len(keys) == 0 {
 			return nil, nil

--- a/session/txn.go
+++ b/session/txn.go
@@ -14,6 +14,7 @@
 package session
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tipb/go-binlog"
@@ -328,6 +330,9 @@ func (st *TxnState) FreshModifiedKeys() ([]kv.Key, error) {
 }
 
 func noNeedToLock(k, v []byte) bool {
+	if !bytes.HasPrefix(k, tablecodec.TablePrefix()) {
+		return false
+	}
 	if len(v) == 1 && v[0] == '0' {
 		// create an non-unique index doesn't need to lock.
 		return true

--- a/session/txn.go
+++ b/session/txn.go
@@ -305,6 +305,10 @@ func (st *TxnState) cleanup() {
 func (st *TxnState) FreshModifiedKeys() ([]kv.Key, error) {
 	keys := make([]kv.Key, 0, st.buf.Len())
 	if err := kv.WalkMemBuffer(st.buf, func(k kv.Key, v []byte) error {
+		if noNeedToLock(k, v) {
+			// We don't need to lock non-unique index.
+			return nil
+		}
 		mb := st.Transaction.GetMemBuffer()
 		if mb == nil {
 			keys = append(keys, k)
@@ -321,6 +325,18 @@ func (st *TxnState) FreshModifiedKeys() ([]kv.Key, error) {
 		return nil, err
 	}
 	return keys, nil
+}
+
+func noNeedToLock(k, v []byte) bool {
+	if len(v) == 1 && v[0] == '0' {
+		// create an non-unique index doesn't need to lock.
+		return true
+	}
+	if len(v) != 0 {
+		return false
+	}
+	// delete an index doesn't need to lock.
+	return k[10] == 'i'
 }
 
 func getBinlogMutation(ctx sessionctx.Context, tableID int64) *binlog.TableMutation {


### PR DESCRIPTION
- fix `err` is shadowed, so failed to return deadlock error
- not all keys needed to lock.