### PR TITLE
executor: fix point get in pessimistic txn

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -352,9 +352,6 @@ func (a *ExecStmt) runSelectForUpdate(ctx context.Context, sctx sessionctx.Conte
 			return nil, errors.Trace(err)
 		}
 
-		// Rollback the statement change before retry it.
-		sctx.StmtRollback()
-
 		if err = e.Open(ctx); err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -352,6 +352,9 @@ func (a *ExecStmt) runSelectForUpdate(ctx context.Context, sctx sessionctx.Conte
 			return nil, errors.Trace(err)
 		}
 
+		// Rollback the statement change before retry it.
+		sctx.StmtRollback()
+
 		if err = e.Open(ctx); err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -437,6 +440,9 @@ func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, sctx sessionctx.Co
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
+
+			// Rollback the statement change before retry it.
+			sctx.StmtRollback()
 
 			if err = e.Open(ctx); err != nil {
 				return nil, errors.Trace(err)


### PR DESCRIPTION
In pessimistic txn, statement retry should use 'for update ts' to read
but point get use the snapshot with start ts
