### PR TITLE
fix that prepared 'select for update' doesn't use pessimistic lock

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -528,19 +528,18 @@ func (a *ExecStmt) buildExecutor(ctx sessionctx.Context) (Executor, error) {
 		return nil, errors.Trace(b.err)
 	}
 
-	if b.hasSelectLock {
-		a.isForUpdate = true
-	}
-
 	// ExecuteExec is not a real Executor, we only use it to build another Executor from a prepared statement.
 	if executorExec, ok := e.(*ExecuteExec); ok {
-		err := executorExec.Build()
+		err := executorExec.Build(b)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		a.isPreparedStmt = true
 		a.Plan = executorExec.plan
 		e = executorExec.stmtExec
+	}
+	if b.hasSelectLock {
+		a.isForUpdate = true
 	}
 	return e, nil
 }

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -212,7 +212,7 @@ func (e *ExecuteExec) Next(ctx context.Context, req *chunk.RecordBatch) error {
 
 // Build builds a prepared statement into an executor.
 // After Build, e.StmtExec will be used to do the real execution.
-func (e *ExecuteExec) Build() error {
+func (e *ExecuteExec) Build(b *executorBuilder) error {
 	ok, err := IsPointGetWithPKOrUniqueKeyByAutoCommit(e.ctx, e.plan)
 	if err != nil {
 		return errors.Trace(err)
@@ -223,7 +223,9 @@ func (e *ExecuteExec) Build() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	b := newExecutorBuilder(e.ctx, e.is)
+
+	b.ctx = e.ctx
+	b.is = e.is
 	stmtExec := b.build(e.plan)
 	if b.err != nil {
 		log.Warn("rebuild plan in EXECUTE statement failed", zap.String("labelName of PREPARE statement", e.name))


### PR DESCRIPTION
In prepared statement, build the execStmt use a new executor builder, so the `isForUpdate` flag is not set correctly
https://github.com/tiancaiamao/tidb/compare/pessimistic...tiancaiamao:pessimistic-patch2?expand=1#diff-350127760839dbfd52d23927f7ff2d95R533

As the `isForUpdate` flag is not set, the `runSelectForUpdate(ctx, sctx, e)` branch doesn't run, so pessimistic lock is not used in prepared  'select for update'. 

This commit fix that.