### PR TITLE
*: add a tidb_pessimistic_lock session variable to control transaction behavior

### DIFF
--- a/executor/simple.go
+++ b/executor/simple.go
@@ -164,7 +164,7 @@ func (e *SimpleExec) executeBegin(ctx context.Context, s *ast.BeginStmt) error {
 	if err != nil {
 		return err
 	}
-	if s.Pessimistic || config.GetGlobalConfig().TxnPessimistic {
+	if s.Pessimistic || config.GetGlobalConfig().TxnPessimistic || e.ctx.GetSessionVars().PessimisticLock {
 		txn.SetOption(kv.Pessimistic, true)
 	}
 	return nil

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -340,6 +340,8 @@ type SessionVars struct {
 
 	// SlowQueryFile indicates which slow query log file for SLOW_QUERY table to parse.
 	SlowQueryFile string
+
+	PessimisticLock bool
 }
 
 // ConnectionInfo present connection used by audit.
@@ -725,6 +727,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		config.GetGlobalConfig().CheckMb4ValueInUTF8 = TiDBOptOn(val)
 	case TiDBSlowQueryFile:
 		s.SlowQueryFile = val
+	case TiDBPessimisticLock:
+		s.PessimisticLock = TiDBOptOn(val)
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -670,6 +670,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBRetryLimit, strconv.Itoa(DefTiDBRetryLimit)},
 	{ScopeGlobal | ScopeSession, TiDBDisableTxnAutoRetry, BoolToIntStr(DefTiDBDisableTxnAutoRetry)},
 	{ScopeGlobal | ScopeSession, TiDBConstraintCheckInPlace, BoolToIntStr(DefTiDBConstraintCheckInPlace)},
+	{ScopeSession, TiDBPessimisticLock, strconv.Itoa(DefTiDBPessimisticLock)},
 	{ScopeSession, TiDBOptimizerSelectivityLevel, strconv.Itoa(DefTiDBOptimizerSelectivityLevel)},
 	{ScopeGlobal | ScopeSession, TiDBEnableWindowFunction, BoolToIntStr(DefEnableWindowFunction)},
 	/* The following variable is defined as session scope but is actually server scope. */

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -122,6 +122,9 @@ const (
 	// tidb_optimizer_selectivity_level is used to control the selectivity estimation level.
 	TiDBOptimizerSelectivityLevel = "tidb_optimizer_selectivity_level"
 
+	// tidb_pessimistic_lock is used to control the transactin behavior.
+	TiDBPessimisticLock = "tidb_pessimistic_lock"
+
 	// tidb_enable_table_partition is used to control table partition feature.
 	// The valid value include auto/on/off:
 	// auto: enable table partition when that feature is implemented.
@@ -282,6 +285,7 @@ const (
 	DefTiDBHashJoinConcurrency       = 5
 	DefTiDBProjectionConcurrency     = 4
 	DefTiDBOptimizerSelectivityLevel = 0
+	DefTiDBPessimisticLock           = 0
 	DefTiDBDDLReorgWorkerCount       = 16
 	DefTiDBDDLReorgBatchSize         = 1024
 	DefTiDBDDLErrorCountLimit        = 512


### PR DESCRIPTION
```
tx1:
set @@tidb_pessimistic_lock = 1;
begin
update t set id = id + 1;

tx2:
set @@tidb_pessimistic_lock = 1;
begin
update t set id = id + 1;     // verify it's blocked
```