### PR TITLE
*: support temporary table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,3 +74,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/pingcap/parser => github.com/tiancaiamao/parser v0.0.0-20210309122426-02fbf958325f

--- a/go.sum
+++ b/go.sum
@@ -360,6 +360,8 @@ github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d h1:4J9HCZVpvDmj2t
 github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
+github.com/tiancaiamao/parser v0.0.0-20210309122426-02fbf958325f h1:CXmxd4VsjbUpFN+nOd/S9iYxQQSxLI8Cdfx5kfBaAYM=
+github.com/tiancaiamao/parser v0.0.0-20210309122426-02fbf958325f/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -943,6 +943,11 @@ func (p *MySQLPrivilege) RequestVerification(activeRoles []*auth.RoleIdentity, u
 
 // DBIsVisible checks whether the user can see the db.
 func (p *MySQLPrivilege) DBIsVisible(user, host, db string) bool {
+	// Temporary table schema is not visible to all users;
+	if strings.EqualFold(db, "tidb_temporary") {
+		return false
+	}
+
 	if record := p.matchUser(user, host); record != nil {
 		if record.Privileges&globalDBVisible > 0 {
 			return true

--- a/session/session.go
+++ b/session/session.go
@@ -1487,6 +1487,13 @@ func (s *session) Close() {
 	if s.sessionVars != nil {
 		s.sessionVars.WithdrawAllPreparedStmt()
 	}
+
+	if len(s.GetSessionVars().TemporaryTable) > 0 {
+		for _, tbl := range s.GetSessionVars().TemporaryTable {
+			_, _, err := s.ExecRestrictedSQL(fmt.Sprintf("DROP TABLE tidb_temporary.%s", tbl))
+			terror.Log(err)
+		}
+	}
 }
 
 // GetSessionVars implements the context.Context interface.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -594,6 +594,8 @@ type SessionVars struct {
 	// WindowingUseHighPrecision determines whether to compute window operations without loss of precision.
 	// see https://dev.mysql.com/doc/refman/8.0/en/window-function-optimization.html for more details.
 	WindowingUseHighPrecision bool
+
+	TemporaryTable map[string]string
 }
 
 // PreparedParams contains the parameters of the current prepared statement when executing it.


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

For the temporary table feature.

### What is changed and how it works?

This is a *Grammar level* compatible implementation.

Use a special hidden database `tidb_temporary`,  temporary tables are just normal tables in that database.

In `plan.Preprocess`, the table name is rewritten to `tidb_temporary.xxx`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)

Create a temporary table with the same name do not overwrite the normal table.

```
use test;
create table tmp (id int);
create temporary table tmp (a int, b int);
```

And the write operation goes to the temporary table:

```
insert into tmp values (1, 2);
select * from tmp;
```

show database should not see the `tidb_temporary` schema:

```
show databases
```

use tidb_temporary reports an error:

```
use tidb_temporary
```

and  show tables do not display the temporary tables:

```
show tables;
```


Switch to another session, the new session can not see the temporary table:
```
mysql -h 127.0.0.1 -u root -P 4000
select * from tmp
```

DDL operation is supported on the temporary table:

```
alter table tmp add index i_b(b);
show create table tmp;
```

Drop the table, this time `tmp` means the temporary table:
```
drop table tmp;
```

Do it a second time, and this time `tmp` refers to the real table:
```
drop table tmp;
```

Multiple session create temporary tables with the same name do not conflict:
```
create table tmp (id int)
```

The temporary table would be clean up after the session exit:
 




